### PR TITLE
Support for more zipfile extensions (.egg, .whl, and .xpi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Supported file extensions:
   * .tgz
   * .war
   * .zip
+  * .egg
+  * .whl
+  * .xpi
 
 ## Installing
 

--- a/spec/common-spec.coffee
+++ b/spec/common-spec.coffee
@@ -25,12 +25,16 @@ describe "Common behavior", ->
 
   describe ".isPathSupported()", ->
     it "returns true for supported path extensions", ->
+      expect(archive.isPathSupported('/a.epub')).toBe true
       expect(archive.isPathSupported('/a.zip')).toBe true
       expect(archive.isPathSupported('/a.jar')).toBe true
       expect(archive.isPathSupported('/a.war')).toBe true
       expect(archive.isPathSupported('/a.tar')).toBe true
       expect(archive.isPathSupported('/a.tgz')).toBe true
       expect(archive.isPathSupported('/a.tar.gz')).toBe true
+      expect(archive.isPathSupported('/a.whl')).toBe true
+      expect(archive.isPathSupported('/a.egg')).toBe true
+      expect(archive.isPathSupported('/a.xpi')).toBe true
       expect(archive.isPathSupported('/a.bar.gz')).toBe false
       expect(archive.isPathSupported('/a.txt')).toBe false
       expect(archive.isPathSupported('/')).toBe false

--- a/src/ls-archive.coffee
+++ b/src/ls-archive.coffee
@@ -176,7 +176,7 @@ isTarPath = (archivePath) ->
 
 isZipPath = (archivePath) ->
   extension = path.extname(archivePath)
-  extension in ['.epub', '.jar', '.love', '.war', '.zip']
+  extension in ['.epub', '.jar', '.love', '.war', '.zip', '.egg', '.whl', '.xpi']
 
 isGzipPath = (archivePath) ->
   path.extname(archivePath) is '.tgz' or


### PR DESCRIPTION
These extensions are zip archives internally: egg and whl are Python packages, and xpi is Mozilla's extension format for Firefox, Thunderbird, etc.