### PR TITLE
Use platform-specific path separator

### DIFF
--- a/spec/common-spec.coffee
+++ b/spec/common-spec.coffee
@@ -1,43 +1,44 @@
 archive = require '../lib/ls-archive'
+path = require 'path'
 
 describe "Common behavior", ->
   describe ".list()", ->
     it "calls back with an error for unsupported extensions", ->
       pathError = null
       callback = (error) -> pathError = error
-      archive.list('/tmp/file.txt', callback)
+      archive.list(path.join('tmp', 'file.txt'), callback)
       waitsFor -> pathError?
       runs -> expect(pathError.message).not.toBeNull()
 
     it "returns undefined", ->
-      expect(archive.list('/tmp/file.zip', ->)).toBeUndefined()
+      expect(archive.list(path.join('tmp', 'file.zip'), ->)).toBeUndefined()
 
   describe ".readFile()", ->
     it "calls back with an error for unsupported extensions", ->
       pathError = null
       callback = (error) -> pathError = error
-      archive.readFile('/tmp/file.txt', 'file.txt', callback)
+      archive.readFile(path.join('tmp', 'file.txt'), 'file.txt', callback)
       waitsFor -> pathError?
       runs -> expect(pathError.message).not.toBeNull()
 
     it "returns undefined", ->
-      expect(archive.readFile('/tmp/file.zip', 'file.txt', ->)).toBeUndefined()
+      expect(archive.readFile(path.join('tmp', 'file.txt'), 'file.txt', ->)).toBeUndefined()
 
   describe ".isPathSupported()", ->
     it "returns true for supported path extensions", ->
-      expect(archive.isPathSupported('/a.epub')).toBe true
-      expect(archive.isPathSupported('/a.zip')).toBe true
-      expect(archive.isPathSupported('/a.jar')).toBe true
-      expect(archive.isPathSupported('/a.war')).toBe true
-      expect(archive.isPathSupported('/a.tar')).toBe true
-      expect(archive.isPathSupported('/a.tgz')).toBe true
-      expect(archive.isPathSupported('/a.tar.gz')).toBe true
-      expect(archive.isPathSupported('/a.whl')).toBe true
-      expect(archive.isPathSupported('/a.egg')).toBe true
-      expect(archive.isPathSupported('/a.xpi')).toBe true
-      expect(archive.isPathSupported('/a.bar.gz')).toBe false
-      expect(archive.isPathSupported('/a.txt')).toBe false
-      expect(archive.isPathSupported('/')).toBe false
+      expect(archive.isPathSupported("#{path.sep}a.epub")).toBe true
+      expect(archive.isPathSupported("#{path.sep}a.zip")).toBe true
+      expect(archive.isPathSupported("#{path.sep}a.jar")).toBe true
+      expect(archive.isPathSupported("#{path.sep}a.war")).toBe true
+      expect(archive.isPathSupported("#{path.sep}a.tar")).toBe true
+      expect(archive.isPathSupported("#{path.sep}a.tgz")).toBe true
+      expect(archive.isPathSupported("#{path.sep}a.tar.gz")).toBe true
+      expect(archive.isPathSupported("#{path.sep}a.whl")).toBe true
+      expect(archive.isPathSupported("#{path.sep}a.egg")).toBe true
+      expect(archive.isPathSupported("#{path.sep}a.xpi")).toBe true
+      expect(archive.isPathSupported("#{path.sep}a.bar.gz")).toBe false
+      expect(archive.isPathSupported("#{path.sep}a.txt")).toBe false
+      expect(archive.isPathSupported("#{path.sep}")).toBe false
       expect(archive.isPathSupported('')).toBe false
       expect(archive.isPathSupported(null)).toBe false
       expect(archive.isPathSupported()).toBe false

--- a/spec/tar-spec.coffee
+++ b/spec/tar-spec.coffee
@@ -46,21 +46,21 @@ describe "tar files", ->
               expect(tree[0].getPath()).toBe 'package'
               expect(tree[0].children.length).toBe 5
               expect(tree[0].children[0].getName()).toBe 'package.json'
-              expect(tree[0].children[0].getPath()).toBe 'package/package.json'
+              expect(tree[0].children[0].getPath()).toBe path.join('package', 'package.json')
               expect(tree[0].children[1].getName()).toBe 'README.md'
-              expect(tree[0].children[1].getPath()).toBe 'package/README.md'
+              expect(tree[0].children[1].getPath()).toBe path.join('package', 'README.md')
               expect(tree[0].children[2].getName()).toBe 'LICENSE.md'
-              expect(tree[0].children[2].getPath()).toBe 'package/LICENSE.md'
+              expect(tree[0].children[2].getPath()).toBe path.join('package', 'LICENSE.md')
               expect(tree[0].children[3].getName()).toBe 'bin'
-              expect(tree[0].children[3].getPath()).toBe 'package/bin'
+              expect(tree[0].children[3].getPath()).toBe path.join('package', 'bin')
               expect(tree[0].children[4].children[0].getName()).toBe 'lister.js'
-              expect(tree[0].children[4].children[0].getPath()).toBe 'package/lib/lister.js'
+              expect(tree[0].children[4].children[0].getPath()).toBe path.join('package', 'lib', 'lister.js')
               expect(tree[0].children[4].children[1].getName()).toBe 'ls-archive-cli.js'
-              expect(tree[0].children[4].children[1].getPath()).toBe 'package/lib/ls-archive-cli.js'
+              expect(tree[0].children[4].children[1].getPath()).toBe path.join('package', 'lib', 'ls-archive-cli.js')
               expect(tree[0].children[4].children[2].getName()).toBe 'ls-archive.js'
-              expect(tree[0].children[4].children[2].getPath()).toBe 'package/lib/ls-archive.js'
+              expect(tree[0].children[4].children[2].getPath()).toBe path.join('package', 'lib', 'ls-archive.js')
               expect(tree[0].children[4].children[3].getName()).toBe 'reader.js'
-              expect(tree[0].children[4].children[3].getPath()).toBe 'package/lib/reader.js'
+              expect(tree[0].children[4].children[3].getPath()).toBe path.join('package', 'lib', 'reader.js')
 
         describe "when the archive has multiple directories at the root", ->
           it "returns archive entries nested under their parent directory", ->
@@ -142,6 +142,6 @@ describe "tar files", ->
         archivePath = path.join(fixturesRoot, 'one-folder.tar')
         pathError = null
         callback = (error, contents) -> pathError = error
-        archive.readFile(archivePath, 'folder/', callback)
+        archive.readFile(archivePath, "folder#{path.sep}", callback)
         waitsFor -> pathError?
         runs -> expect(pathError.message.length).toBeGreaterThan 0

--- a/spec/zip-spec.coffee
+++ b/spec/zip-spec.coffee
@@ -113,6 +113,6 @@ describe "zip files", ->
         archivePath = path.join(fixturesRoot, 'one-folder.zip')
         pathError = null
         callback = (error, contents) -> pathError = error
-        archive.readFile(archivePath, 'folder/', callback)
+        archive.readFile(archivePath, "folder#{path.sep}", callback)
         waitsFor -> pathError?
         runs -> expect(pathError.message.length).toBeGreaterThan 0

--- a/src/ls-archive.coffee
+++ b/src/ls-archive.coffee
@@ -9,7 +9,7 @@ class ArchiveEntry
   add: (entry) ->
     return false unless @isParentOf(entry)
 
-    segments = entry.getPath().substring(@getPath().length + 1).split('/')
+    segments = entry.getPath().substring(@getPath().length + 1).split(path.sep)
     return false if segments.length is 0
 
     if segments.length is 1
@@ -19,7 +19,7 @@ class ArchiveEntry
       name = segments[0]
       child = findEntryWithName(@children, name)
       unless child?
-        child = new ArchiveEntry("#{@getPath()}/#{name}", 5)
+        child = new ArchiveEntry("#{@getPath()}#{path.sep}#{name}", 5)
         @children.push(child)
       if child.isDirectory()
         child.add(entry)
@@ -27,7 +27,7 @@ class ArchiveEntry
         false
 
   isParentOf: (entry) ->
-    @isDirectory() and entry.getPath().indexOf("#{@getPath()}/") is 0
+    @isDirectory() and entry.getPath().indexOf("#{@getPath()}#{path.sep}") is 0
 
   getPath: -> @path
   getName: -> @name ?= path.basename(@path)
@@ -42,7 +42,7 @@ findEntryWithName = (entries, name) ->
 convertToTree = (entries) ->
   rootEntries = []
   for entry in entries
-    segments = entry.getPath().split('/')
+    segments = entry.getPath().split(path.sep)
     if segments.length is 1
       rootEntries.push(entry)
     else
@@ -69,7 +69,7 @@ listZip = (archivePath, options, callback) ->
   zipStream.on('error', callback)
   zipStream.on 'list', (files) ->
     for file in files
-      if file[-1..] is '/'
+      if file[-1..] is path.sep
         entryPath = file[0...-1]
         entryType = 5
       else
@@ -98,7 +98,7 @@ listTarStream = (inputStream, options, callback) ->
   tarStream = inputStream.pipe(require('tar').Parse())
   tarStream.on 'error', callback
   tarStream.on 'entry', (entry) ->
-    if entry.props.path[-1..] is '/'
+    if entry.props.path[-1..] is path.sep
       entryPath = entry.props.path[0...-1]
     else
       entryPath = entry.props.path

--- a/src/ls-archive.coffee
+++ b/src/ls-archive.coffee
@@ -98,11 +98,12 @@ listTarStream = (inputStream, options, callback) ->
   tarStream = inputStream.pipe(require('tar').Parse())
   tarStream.on 'error', callback
   tarStream.on 'entry', (entry) ->
-    if entry.props.path[-1..] is path.sep
+    if entry.props.path[-1..] is '/'
       entryPath = entry.props.path[0...-1]
     else
       entryPath = entry.props.path
     entryType = parseInt(entry.props.type)
+    entryPath = entryPath.replace(/\//g, path.sep)
     entries.push(new ArchiveEntry(entryPath, entryType))
   tarStream.on 'end', ->
     entries = convertToTree(entries) if options.tree
@@ -159,7 +160,7 @@ readFileFromTarStream = (inputStream, archivePath, filePath, callback) ->
 
   tarStream.on 'error', callback
   tarStream.on 'entry', (entry) ->
-    return unless filePath is entry.props.path
+    return unless filePath is entry.props.path.replace(/\//g, path.sep)
 
     if entry.props.type is '0'
       readEntry(entry, callback)


### PR DESCRIPTION
This fixes https://github.com/atom/archive-view/issues/16.

Currently, `/` is used in all places as the path separator, which causes the tests of node-ls-archive to fail on Windows and the problems described in https://github.com/atom/archive-view/issues/16:

```
C:\node-ls-archive [(v1.1.0)]> npm test

> ls-archive@1.1.0 test C:\node-ls-archive
> grunt test

Running "clean" task

Running "coffeelint:src" (coffeelint) task
>> 2 files lint free.

Running "coffeelint:test" (coffeelint) task
>> 4 files lint free.

Running "coffee:glob_to_multiple" (coffee) task

Running "shell:test" (shell) task
.................................FF.......

zip files
  .list()
    when the archive file exists
      when the tree option is set to true
        it returns archive entries nested under their parent directory
          Expected 9 to be 2. (spec\zip-spec.coffee:43:33)
          Expected 'd1\' to be 'd1'. (spec\zip-spec.coffee:45:39)
          TypeError: Cannot read property '0' of undefined (spec\zip-spec.coffee:46:37)
      it returns folders in the zip archive
        Expected 'folder\' to be 'folder'. (spec\zip-spec.coffee:31:36)
        Expected false to be true. (spec\zip-spec.coffee:32:45)
        Expected true to be false. (spec\zip-spec.coffee:33:40)

Finished in 0.885 seconds
42 tests, 119 assertions, 6 failures, 0 skipped
```

After I switched the library to use a platform specific path separator in e27c097, I noticed that the tests were still failing. And then realized that the node-tar library [always uses `/` as the path separator](https://github.com/npm/node-tar/blob/d6a815dd85690dcd54c962bdb54a5edeb3b2e5d8/lib/extract.js#L39), even on Windows, while the decompress-zip library uses os-dependent path separators (I double-checked this by running the specs on Windows and logging the paths from entries to the console). It was this inconsistency that was causing the real problem, and 32ce3e9 takes care of that.

With these changes, all tests are passing on Windows (and OSX and Linux):

```
C:\node-ls-archive [iz-use-path-sep-and-join]> npm test

> ls-archive@1.1.0 test C:\node-ls-archive
> grunt test

Running "clean" task

Running "coffeelint:src" (coffeelint) task
>> 2 files lint free.

Running "coffeelint:test" (coffeelint) task
>> 4 files lint free.

Running "coffee:glob_to_multiple" (coffee) task

Running "shell:test" (shell) task
..........................................

Finished in 0.822 seconds
42 tests, 126 assertions, 0 failures, 0 skipped

Done, without errors.
```

And the example `nested.zip` is now correctly handled in archive view on Windows.

Before:

![screen shot 2015-06-05 at 21 51 37](https://cloud.githubusercontent.com/assets/38924/8014170/c3b13aee-0bce-11e5-9a87-e4dd2802e1b8.png)

After:

![screen shot 2015-06-05 at 21 55 47](https://cloud.githubusercontent.com/assets/38924/8014175/cf5e40e4-0bce-11e5-829b-1e583434998a.png)

I guess that an alternative approach would be to keep using `/` everywhere and special-case handling of paths in ZIPs (convert platform-specific path separators to `/` in those paths). That would make the diff much smaller, but I thought that using correct platform-specific path separators is a better way to go and might save us from problems in the future as well.

cc @kevinsawicki for :eyes: 