### PR TITLE
Update tar to use newer version of graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "tar": "~0.1.17",
+    "tar": "^2.2.1",
     "optimist": "~0.5.2",
     "async": "~0.2.9",
     "colors": "~0.6.2",


### PR DESCRIPTION
There's two main reasons for this PR.
1. The current version of tar that this package is on is using an outdated version of graceful-fs.  In order for Atom to be on Node 6, that version of graceful-fs needs to be updated (/cc @thomasjo).
2. I'm currently debugging a very weird error in one of my Atom PRs that seems to be stemming from tar's version of graceful-fs.