### PR TITLE
Update decompress-zip to use newer version of graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "optimist": "~0.5.2",
     "async": "~0.2.9",
     "colors": "~0.6.2",
-    "decompress-zip": "0.1.0",
+    "decompress-zip": "^0.3.0",
     "rimraf": "~2.2.6",
     "tmp": "0.0.23"
   }


### PR DESCRIPTION
@as-cii: Sorry about this, but I happened to miss this dependency.
Just ran `npm ls graceful-fs` in the archive-view folder and I'm pretty sure this is the last one that's using graceful-fs@3.

The weird part though is that 1) archive-view is still failing, and 2) decompress-zip shouldn't have anything to do with it based on the stacktrace.
