### PR TITLE
⬆️decompress-zip@0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-contrib-coffee": "~0.9.0",
-    "coffee-script": "~1.7.0",
+    "coffeescript": "~1.7.0",
     "grunt-cli": "~0.1.6",
     "grunt-shell": "~0.2.2",
     "jasmine-focused": "1.x",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "optimist": "~0.5.2",
     "async": "~0.2.9",
     "colors": "~0.6.2",
-    "decompress-zip": "0.1.0",
+    "decompress-zip": "0.3.1",
     "rimraf": "~2.2.6",
     "tmp": "^0.0.31"
   }


### PR DESCRIPTION
When running Atom on Electron 2.0.0 (https://github.com/atom/atom/pull/17273), we see the [following error in the archive-view tests](https://circleci.com/gh/atom/atom/7463):

```
Package tests failed for archive-view:
./Users/distiller/atom/out/Atom.app/Contents/Frameworks/Atom Helper.app/Contents/MacOS/Atom Helper[9447]: ../../vendor/node/src/async-wrap.cc:357:void node::SetupHooks(const FunctionCallbackInfo<v8::Value> &): Assertion `env->async_hooks_init_function().IsEmpty()' failed.
 1: node::Abort() [/Users/distiller/atom/out/Atom.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libnode.dylib]
 2: node::Assert(char const* const (*) [4]) [/Users/distiller/atom/out/Atom.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libnode.dylib]
 3: node::AsyncWrap::Initialize(v8::Local<v8::Object>, v8::Local<v8::Value>, v8::Local<v8::Context>) [/Users/distiller/atom/out/Atom.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libnode.dylib]
 4: v8::internal::StrDup(char const*) [/Users/distiller/atom/out/Atom.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libnode.dylib]
 5: v8::internal::compiler::BranchElimination::ControlPathConditions::operator==(v8::internal::compiler::BranchElimination::ControlPathConditions const&) const [/Users/distiller/atom/out/Atom.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libnode.dylib]
 6: v8::internal::compiler::BranchElimination::ControlPathConditions::operator==(v8::internal::compiler::BranchElimination::ControlPathConditions const&) const [/Users/distiller/atom/out/Atom.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libnode.dylib]
 7: 0x27e9ef30463d
 8: 0x27e9ef3f45bc
 9: 0x27e9ef3bf98e
2018-05-04 11:53:40.199 Atom[9443:21976] Renderer process crashed, exiting
```

This error appears to be due to https://github.com/electron/electron/issues/10905, which [occurs when code makes use of the natives package](https://github.com/electron/electron/issues/10905#issuecomment-379307789).

[atom/archive-view](https://github.com/atom/archive-view) depends on [atom/node-ls-archive](https://github.com/atom/node-ls-archive), which depends on [bower/decompress-zip](https://github.com/bower/decompress-zip), which depends on [isaacs/node-graceful-fs](https://github.com/isaacs/node-graceful-fs). Older versions of [isaacs/node-graceful-fs](https://github.com/isaacs/node-graceful-fs) made use of the natives package, and [that use was removed in 4.0.0](https://github.com/isaacs/node-graceful-fs/compare/v3.0.11...v4.0.0#diff-7438fc91d31b61d1c67fa0a385027949L8).

[decompress-zip 0.2.1](https://github.com/bower/decompress-zip/releases/tag/0.2.1) updates its dependency on node-graceful-fs from [3.0.0 to 4.1.3](https://github.com/bower/decompress-zip/commit/ad410ebe3f8b3089a7f7d879034ff1d5e491684f) and that should resolve the problem we're seeing. 🤞

It would probably suffice to upgrade to decompress-zip 0.2.1, but since 0.3.1 is the latest version, this pull request opts for 0.3.1.

/fyi @codebytere 