### PR TITLE
Remove decompress-zip dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "grunt-cli": "~0.1.6",
     "grunt-shell": "~0.2.2",
     "jasmine-focused": "1.x",
-    "grunt-coffeelint": "0.0.6",
-    "rimraf": "~2.1.4"
+    "grunt-coffeelint": "0.0.6"
   },
   "scripts": {
     "prepublish": "grunt",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "optimist": "~0.5.2",
     "async": "~0.2.9",
     "colors": "~0.6.2",
-    "decompress-zip": "0.3.1",
     "rimraf": "~2.2.6",
-    "tmp": "^0.0.31"
+    "yauzl": "^2.9.1"
   }
 }

--- a/spec/zip-spec.coffee
+++ b/spec/zip-spec.coffee
@@ -116,3 +116,12 @@ describe "zip files", ->
         archive.readFile(archivePath, "folder#{path.sep}", callback)
         waitsFor -> pathError?
         runs -> expect(pathError.message.length).toBeGreaterThan 0
+
+    describe "when the archive contains nested directories", ->
+      it "calls back with the contents of the given path", ->
+        archivePath = path.join(fixturesRoot, 'nested.zip')
+        pathContents = null
+        callback = (error, contents) -> pathContents = contents
+        archive.readFile(archivePath, 'd1/d2/f1.txt', callback)
+        waitsFor -> pathContents?
+        runs -> expect(pathContents.toString()).toBe ''


### PR DESCRIPTION
## Background Information
The `string_decoder` issues that @jasonrudolph and myself have been experiencing on [atom/atom](https://github.com/atom/atom) `master` is inadvertently caused by `decompress-zip`, which via its dependency chain pulls in a ridiculously outdated version of `string_decoder` that is wildly out of sync with the implementation found in current versions of Node. 

The problem ultimately seems to come down to how we flatten out npm dependencies, and multiple packages relying on different versions of `string_decoder`. For some reason this is not a problem when everything is bundled in ASAR, but is a problem when running on local builds (unless launched in dev mode).  If anyone is able to explain this, I'd really appreciate some additional insights here.

## Description of the Change
Instead of trying to fix the problems listed above directly, this PR replaces the `decompress-zip` dependency with [`yauzl`](https://www.npmjs.com/package/yauzl).

## TODO
- [x] Ensure there are not regressions in [`archive-view`](https://github.com/atom/archive-view) with this PR.

---
## Additional note
While working on this PR, I realized that this package is in desperate need of some ❤️
Unless someone objects, I want to do a few things in separate PRs;
1. Improve spec suite; verify sanity of current tests, and potentially expand with some additional tests to prepare for the tasks below (and simply improve our test coverage).
1. Refactor, reformat, and clean-up code.
1. Convert implementation to modern JavaScript.