### PR TITLE
Add appveyor.yml for Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: "{build}"
+
+image: Visual Studio 2017
+platform:
+  - x64
+
+cache:
+  - node_modules
+
+install:
+  - ps: Install-Product node 8 x64
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ platform:
 cache:
   - node_modules
 
+branches:
+  only:
+    - /master|^v\d+\.\d+\.\d+$/
+
 install:
   - ps: Install-Product node 8 x64
   - npm install


### PR DESCRIPTION
In the latest release (v1.3.0), the tests pass on Linux, but they fail on Windows. This is a regression from the previous release (v1.2.5), in which the tests passed on both Linux and Windows. To help us detect such regressions in the future, this pull request configures CI to run on Windows via AppVeyor (in addition to the pre-existing CI on Linux on Travis). 

Note: I'll follow-up with another pull request soon that attempts to resolve the failing tests.

---

AppVeyor build at v1.2.5: https://ci.appveyor.com/project/Atom/node-ls-archive/build/4
AppVeyor build at v1.3.0: https://ci.appveyor.com/project/Atom/node-ls-archive/build/5