### PR TITLE
Reconfigure Travis CI to use current versions of Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ notifications:
     on_failure: change
 
 node_js:
-  - 0.10
+  - 8
+  - 10
+  - 12
+  - 13
 
 branches:
   only:


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

### Identify the Bug

The Travis CI pipeline is currently broken because it uses an ancient version of Node.js.
This leads to pull requests (eg. #14) failing, even though they don't introduce new bugs.

### Description of the Change

This PR changes the Travis config so that all currently supported versions plus 8 (because that's just two weeks out of support) are being tested.
Node.js 8 is also used in `appveyor.yml`.

### Alternate Designs

Um, just remove Travis? But then there would be no CI for Linux which wouldn't be that good.

### Possible Drawbacks

None? The code might already be broken on old Node.js versions and noone would know.

### Verification Process

See whether the Travis build succeeds.

### Release Notes

N/A
